### PR TITLE
feat: Add HEIC to JPEG conversion for image uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "heic-convert": "^2.1.0",
         "lucide-react": "^0.544.0",
         "next": "15.5.3",
         "next-auth": "^4.24.11",
@@ -7577,6 +7578,32 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/heic-convert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/heic-convert/-/heic-convert-2.1.0.tgz",
+      "integrity": "sha512-1qDuRvEHifTVAj3pFIgkqGgJIr0M3X7cxEPjEp0oG4mo8GFjq99DpCo8Eg3kg17Cy0MTjxpFdoBHOatj7ZVKtg==",
+      "license": "ISC",
+      "dependencies": {
+        "heic-decode": "^2.0.0",
+        "jpeg-js": "^0.4.4",
+        "pngjs": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/heic-decode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/heic-decode/-/heic-decode-2.1.0.tgz",
+      "integrity": "sha512-0fB3O3WMk38+PScbHLVp66jcNhsZ/ErtQ6u2lMYu/YxXgbBtl+oKOhGQHa4RpvE68k8IzbWkABzHnyAIjR758A==",
+      "license": "ISC",
+      "dependencies": {
+        "libheif-js": "^1.19.8"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/highlight.js": {
       "version": "11.11.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
@@ -8314,6 +8341,12 @@
         }
       }
     },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8468,6 +8501,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/libheif-js": {
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.19.8.tgz",
+      "integrity": "sha512-vQJWusIxO7wavpON1dusciL8Go9jsIQ+EUrckauFYAiSTjcmLAsuJh3SszLpvkwPci3JcL41ek2n+LUZGFpPIQ==",
+      "license": "LGPL-3.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/lightningcss": {
@@ -10897,6 +10939,15 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "heic-convert": "^2.1.0",
     "lucide-react": "^0.544.0",
     "next": "15.5.3",
     "next-auth": "^4.24.11",

--- a/src/app/api/account/reviews/upload-media/route.ts
+++ b/src/app/api/account/reviews/upload-media/route.ts
@@ -1,5 +1,6 @@
 // app/api/account/reviews/upload-media/route.ts
 import { auth } from "@/lib/auth/auth";
+import { processImageFile } from "@/lib/heicConverter";
 import { put } from "@vercel/blob";
 import { NextResponse } from "next/server";
 
@@ -61,8 +62,14 @@ export async function POST(req: Request) {
       );
     }
 
+    // Convert HEIC to JPEG if it's a photo
+    let processedFile = file;
+    if (!isVideo) {
+      processedFile = await processImageFile(file, 0.92);
+    }
+
     // Sanitize filename
-    const originalName = file.name || "file";
+    const originalName = processedFile.name || "file";
     const sanitized = originalName.replace(/[^\w\d.-]/g, "_").slice(0, 200);
     const timestamp = Date.now();
 
@@ -71,7 +78,7 @@ export async function POST(req: Request) {
     const key = `${mediaFolder}/${session.user.id}/${timestamp}-${sanitized}`;
 
     // Upload to blob storage
-    const { url } = await put(key, file, {
+    const { url } = await put(key, processedFile, {
       access: "public",
       token: process.env.BLOB_READ_WRITE_TOKEN,
       addRandomSuffix: false,
@@ -86,8 +93,8 @@ export async function POST(req: Request) {
       url,
       key,
       mediaType,
-      size: file.size,
-      mimeType: file.type,
+      size: processedFile.size,
+      mimeType: processedFile.type,
     });
   } catch (error) {
     console.error("Review media upload error:", error);

--- a/src/app/api/blog/upload-image/route.ts
+++ b/src/app/api/blog/upload-image/route.ts
@@ -1,4 +1,5 @@
 import { authOptions } from "@/lib/auth/auth-options";
+import { processImageFile } from "@/lib/heicConverter";
 import { put } from "@vercel/blob";
 import { getServerSession } from "next-auth";
 import { NextResponse } from "next/server";
@@ -71,8 +72,11 @@ export async function POST(req: Request) {
       );
     }
 
+    // Convert HEIC to JPEG if needed
+    const processedFile = await processImageFile(file, 0.92);
+
     // Sanitize filename
-    const originalName = file.name || "image";
+    const originalName = processedFile.name || "image";
     const sanitized = originalName.replace(/[^\w\d.-]/g, "_").slice(0, 100);
     const timestamp = Date.now();
     const type =
@@ -83,7 +87,7 @@ export async function POST(req: Request) {
     const key = `blog/${userId}/${type}/${timestamp}-${sanitized}`;
 
     // Upload to Vercel Blob
-    const { url } = await put(key, file, {
+    const { url } = await put(key, processedFile, {
       access: "public",
       token: process.env.BLOB_READ_WRITE_TOKEN,
       addRandomSuffix: false,

--- a/src/lib/__tests__/heicConverter.test.ts
+++ b/src/lib/__tests__/heicConverter.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { isHeicFile } from "../heicConverter";
+
+describe("heicConverter", () => {
+  describe("isHeicFile", () => {
+    it("should detect HEIC files by extension", () => {
+      const file = new File([], "photo.heic", { type: "image/heic" });
+      expect(isHeicFile(file)).toBe(true);
+    });
+
+    it("should detect HEIF files by extension", () => {
+      const file = new File([], "photo.heif", { type: "image/heif" });
+      expect(isHeicFile(file)).toBe(true);
+    });
+
+    it("should detect HEIC files by MIME type", () => {
+      const file = new File([], "photo.jpg", { type: "image/heic" });
+      expect(isHeicFile(file)).toBe(true);
+    });
+
+    it("should detect HEIF files by MIME type", () => {
+      const file = new File([], "photo.jpg", { type: "image/heif" });
+      expect(isHeicFile(file)).toBe(true);
+    });
+
+    it("should handle uppercase extensions", () => {
+      const file = new File([], "photo.HEIC", { type: "image/jpeg" });
+      expect(isHeicFile(file)).toBe(true);
+    });
+
+    it("should handle uppercase MIME types", () => {
+      const file = new File([], "photo.jpg", { type: "IMAGE/HEIC" });
+      expect(isHeicFile(file)).toBe(true);
+    });
+
+    it("should not detect regular JPEG files", () => {
+      const file = new File([], "photo.jpg", { type: "image/jpeg" });
+      expect(isHeicFile(file)).toBe(false);
+    });
+
+    it("should not detect PNG files", () => {
+      const file = new File([], "photo.png", { type: "image/png" });
+      expect(isHeicFile(file)).toBe(false);
+    });
+
+    it("should not detect WebP files", () => {
+      const file = new File([], "photo.webp", { type: "image/webp" });
+      expect(isHeicFile(file)).toBe(false);
+    });
+  });
+});

--- a/src/lib/heicConverter.ts
+++ b/src/lib/heicConverter.ts
@@ -1,0 +1,96 @@
+/**
+ * HEIC to JPEG Conversion Utility
+ * Converts HEIC/HEIF images to JPEG format for web compatibility
+ */
+
+import convert from "heic-convert";
+
+/**
+ * Check if a file is HEIC/HEIF format
+ */
+export function isHeicFile(file: File): boolean {
+  const name = file.name.toLowerCase();
+  const type = file.type.toLowerCase();
+
+  return (
+    name.endsWith(".heic") ||
+    name.endsWith(".heif") ||
+    type === "image/heic" ||
+    type === "image/heif"
+  );
+}
+
+/**
+ * Convert HEIC file to JPEG
+ * @param file - HEIC file to convert
+ * @param quality - JPEG quality (0-1), default 0.92
+ * @returns Converted File object in JPEG format
+ */
+export async function convertHeicToJpeg(
+  file: File,
+  quality: number = 0.92
+): Promise<File> {
+  try {
+    // Read file as ArrayBuffer
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    // Convert HEIC to JPEG
+    const outputBuffer = await convert({
+      buffer,
+      format: "JPEG",
+      quality, // 0-1 scale
+    });
+
+    // Create new File object with JPEG data
+    // Convert Buffer to Uint8Array for Blob compatibility
+    const uint8Array = new Uint8Array(outputBuffer);
+    const jpegBlob = new Blob([uint8Array], { type: "image/jpeg" });
+
+    // Generate new filename: replace .heic/.heif with .jpg
+    const originalName = file.name.replace(/\.(heic|heif)$/i, ".jpg");
+    const jpegFile = new File([jpegBlob], originalName, {
+      type: "image/jpeg",
+      lastModified: Date.now(),
+    });
+
+    console.log(
+      `[heic-convert] Converted ${file.name} (${formatBytes(file.size)}) to ${jpegFile.name} (${formatBytes(jpegFile.size)})`
+    );
+
+    return jpegFile;
+  } catch (error) {
+    console.error("[heic-convert] Conversion failed:", error);
+    throw new Error(
+      `Failed to convert HEIC image: ${error instanceof Error ? error.message : "Unknown error"}`
+    );
+  }
+}
+
+/**
+ * Process file - convert if HEIC, otherwise return as-is
+ * @param file - File to process
+ * @param quality - JPEG quality if conversion needed (0-1), default 0.92
+ * @returns Original file or converted JPEG file
+ */
+export async function processImageFile(
+  file: File,
+  quality: number = 0.92
+): Promise<File> {
+  if (isHeicFile(file)) {
+    console.log(`[heic-convert] Detected HEIC file: ${file.name}`);
+    return await convertHeicToJpeg(file, quality);
+  }
+  return file;
+}
+
+/**
+ * Format bytes to human-readable string
+ */
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 Bytes";
+  const k = 1024;
+  const sizes = ["Bytes", "KB", "MB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${Math.round((bytes / Math.pow(k, i)) * 100) / 100} ${sizes[i]}`;
+}

--- a/src/types/heic-convert.d.ts
+++ b/src/types/heic-convert.d.ts
@@ -1,0 +1,11 @@
+declare module "heic-convert" {
+  interface ConvertOptions {
+    buffer: Buffer;
+    format: "JPEG" | "PNG";
+    quality: number; // 0-1 for JPEG
+  }
+
+  function convert(options: ConvertOptions): Promise<Buffer>;
+
+  export default convert;
+}


### PR DESCRIPTION
- Install heic-convert library for server-side image conversion
- Create heicConverter utility with detection and conversion logic
- Add TypeScript type definitions for heic-convert module
- Update /api/account/reviews/upload-media to convert HEIC photos
- Update /api/blog/upload-image to convert HEIC images
- Add unit tests for HEIC file detection
- Set JPEG quality to 92% for optimal size/quality balance
- Log conversion events for monitoring

Fixes: HEIC images not loading in browsers (Chrome, Firefox, Edge) All HEIC/HEIF uploads are now automatically converted to JPEG