### PR TITLE
fix(payment): sanitize name and phone for Senang Pay requirements

### DIFF
--- a/src/app/(marketplace)/book/payment/[bookingId]/page.tsx
+++ b/src/app/(marketplace)/book/payment/[bookingId]/page.tsx
@@ -15,6 +15,8 @@ import {
   getSecretKey,
   getSenangPayUrl,
   isForceMockMode,
+  sanitizeName,
+  sanitizePhone,
   validateSenangPayConfig,
 } from "@/lib/payment/senangpay";
 import { enrichBookingWithTripData } from "@/lib/services/booking-display-service";
@@ -165,13 +167,19 @@ export default async function PaymentPage({
     });
 
     // Get user details for payment
-    const userName =
+    const rawName =
       booking.guestFirstName && booking.guestLastName
         ? `${booking.guestFirstName} ${booking.guestLastName}`
         : session?.user?.name || "Guest";
 
+    const rawPhone = booking.guestPhone || "";
+
+    // Sanitize name and phone to meet Senang Pay requirements
+    // Name: only letters and spaces (no special characters)
+    // Phone: only digits (no spaces, dashes, parentheses)
+    const userName = sanitizeName(rawName);
+    const userPhone = sanitizePhone(rawPhone);
     const userEmail = booking.guestEmail || session?.user?.email || "";
-    const userPhone = booking.guestPhone || "";
 
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3001";
 

--- a/src/lib/payment/__tests__/senangpay.test.ts
+++ b/src/lib/payment/__tests__/senangpay.test.ts
@@ -643,4 +643,79 @@ describe("senangpay utilities", () => {
       expect(isValid).toBe(true);
     });
   });
+
+  describe("sanitizeName", () => {
+    it("should keep valid names unchanged", async () => {
+      const { sanitizeName } = await import("../senangpay");
+      expect(sanitizeName("John Doe")).toBe("John Doe");
+      expect(sanitizeName("Ahmad bin Ali")).toBe("Ahmad bin Ali");
+      expect(sanitizeName("Mary Jane")).toBe("Mary Jane");
+    });
+
+    it("should remove special characters", async () => {
+      const { sanitizeName } = await import("../senangpay");
+      expect(sanitizeName("John-Paul")).toBe("JohnPaul");
+      expect(sanitizeName("O'Brien")).toBe("OBrien");
+      expect(sanitizeName("John & Jane")).toBe("John Jane"); // & is removed, double space becomes single
+      expect(sanitizeName("Dr. Smith")).toBe("Dr Smith");
+    });
+
+    it("should remove numbers", async () => {
+      const { sanitizeName } = await import("../senangpay");
+      expect(sanitizeName("John123")).toBe("John");
+      expect(sanitizeName("Agent007")).toBe("Agent");
+    });
+
+    it("should handle multiple spaces", async () => {
+      const { sanitizeName } = await import("../senangpay");
+      expect(sanitizeName("John    Doe")).toBe("John Doe");
+      expect(sanitizeName("  Ahmad  bin  Ali  ")).toBe("Ahmad bin Ali");
+    });
+
+    it("should handle empty or invalid input", async () => {
+      const { sanitizeName } = await import("../senangpay");
+      expect(sanitizeName("")).toBe("");
+      expect(sanitizeName("123")).toBe("");
+      expect(sanitizeName("@#$")).toBe("");
+    });
+  });
+
+  describe("sanitizePhone", () => {
+    it("should keep valid phone numbers unchanged", async () => {
+      const { sanitizePhone } = await import("../senangpay");
+      expect(sanitizePhone("0128888888")).toBe("0128888888");
+      expect(sanitizePhone("0123456789")).toBe("0123456789");
+    });
+
+    it("should remove spaces and dashes", async () => {
+      const { sanitizePhone } = await import("../senangpay");
+      expect(sanitizePhone("012-888-8888")).toBe("0128888888");
+      expect(sanitizePhone("012 888 8888")).toBe("0128888888");
+      expect(sanitizePhone("012 - 888 - 8888")).toBe("0128888888");
+    });
+
+    it("should remove parentheses", async () => {
+      const { sanitizePhone } = await import("../senangpay");
+      expect(sanitizePhone("(012) 888-8888")).toBe("0128888888");
+      expect(sanitizePhone("(012)8888888")).toBe("0128888888");
+    });
+
+    it("should handle international format", async () => {
+      const { sanitizePhone } = await import("../senangpay");
+      expect(sanitizePhone("+60128888888")).toBe("0128888888");
+      expect(sanitizePhone("+60 12 888 8888")).toBe("0128888888");
+      expect(sanitizePhone("60128888888")).toBe("0128888888");
+    });
+
+    it("should handle empty input", async () => {
+      const { sanitizePhone } = await import("../senangpay");
+      expect(sanitizePhone("")).toBe("");
+    });
+
+    it("should remove all non-digit characters", async () => {
+      const { sanitizePhone } = await import("../senangpay");
+      expect(sanitizePhone("tel:0128888888")).toBe("0128888888");
+      expect(sanitizePhone("Phone: 012-888-8888")).toBe("0128888888");
+    });
+  });
 });

--- a/src/lib/payment/senangpay.ts
+++ b/src/lib/payment/senangpay.ts
@@ -11,6 +11,67 @@
 
 import crypto from "crypto";
 
+/**
+ * Sanitize name for Senang Pay requirements
+ *
+ * Senang Pay requirements:
+ * - Only alphabet and spaces allowed
+ * - No special characters (no &, -, /, etc.)
+ * - No numbers
+ *
+ * @param name - Raw name input
+ * @returns Sanitized name with only letters and spaces
+ *
+ * @example
+ * ```typescript
+ * sanitizeName("John Doe") // "John Doe"
+ * sanitizeName("John-Paul O'Brien") // "JohnPaul OBrien"
+ * sanitizeName("Ahmad bin Ali") // "Ahmad bin Ali"
+ * ```
+ */
+export function sanitizeName(name: string): string {
+  if (!name) return "";
+
+  // Remove all characters except letters and spaces
+  // This removes: numbers, special characters (&, -, /, @, etc.)
+  return name
+    .replace(/[^a-zA-Z\s]/g, "") // Keep only letters and spaces
+    .replace(/\s+/g, " ") // Replace multiple spaces with single space
+    .trim();
+}
+
+/**
+ * Sanitize phone number for Senang Pay requirements
+ *
+ * Senang Pay requirements:
+ * - Numbers only
+ * - Format: 0128888888 (starts with 0, 10-11 digits)
+ * - No spaces, dashes, or parentheses
+ *
+ * @param phone - Raw phone input
+ * @returns Sanitized phone with only digits
+ *
+ * @example
+ * ```typescript
+ * sanitizePhone("012-888-8888") // "0128888888"
+ * sanitizePhone("+60 12 888 8888") // "60128888888"
+ * sanitizePhone("(012) 888-8888") // "0128888888"
+ * ```
+ */
+export function sanitizePhone(phone: string): string {
+  if (!phone) return "";
+
+  // Remove all non-digit characters
+  let cleaned = phone.replace(/\D/g, "");
+
+  // If starts with country code +60, remove it and add 0
+  if (cleaned.startsWith("60")) {
+    cleaned = "0" + cleaned.substring(2);
+  }
+
+  return cleaned;
+}
+
 export interface PaymentDetails {
   merchantId: string;
   secretKey: string;


### PR DESCRIPTION
- Add sanitizeName() - removes special characters, keeps letters/spaces only
- Add sanitizePhone() - removes formatting, keeps digits only
- Convert international phone format (+60) to local format (0)
- Apply sanitization in payment page before sending to gateway
- Add 11 new tests for sanitization functions (65 total passing)
- Fixes 'invalid character' error from Senang Pay
- Fixes name and phone not auto-populating on payment page